### PR TITLE
Use nix 2.18.1 in CI to unbreak node2nix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Build"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v9
         with:
           nix-installer-tag: v0.15.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: DeterminateSystems/nix-installer-action@v9
+        with:
+          nix-installer-tag: v0.15.1
+      - uses: DeterminateSystems/magic-nix-cache-action@v3
       - run: nix --print-build-logs build .


### PR DESCRIPTION
While working on [Die-KoMa/die-koma.org](https://github.com/Die-KoMa/die-koma.org/), @thelegy and I encountered the same issue with a `node2nix` build failing in CI. Downgrading the `nix` to 2.18.1 fixes the builds.